### PR TITLE
Detect harp.json file and various index.* files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Heroku Buildpack for Static Sites with Harp
+# Harp Buildpack
 
-This is a Heroku buildpack for serving static sites using [Harp](http://harpjs.com/). Harp serves Jade, Markdown, EJS, CoffeeScript, Sass, LESS and Stylus as HTML, CSS & JavaScript. You don't have to use preprocessors though: This buildpack works with with regular old HTML, CSS, and JavaScript files too.
+This is a [buildpack](https://devcenter.heroku.com/articles/buildpacks) for deploying static sites to Heroku. It's powered by [Harp](http://harpjs.com/), a Node.js server that automatically converts Jade, Markdown, EJS, CoffeeScript, Sass, LESS and Stylus to HTML, CSS & JavaScript. You don't have to use preprocessors though: this buildpack works with with regular old HTML, CSS, and JavaScript files too.
 
 ## Requirements
 
-You'll need an `index.jade` or `index.html` file in the root directory of your repository.
+You'll need a `harp.json`, `index.ejs`, `index.jade`, `index.html`, or `index.md` file in the root directory of your app.
+
+## Demo
+
+Check out the sample app at [harp-sample.herokuapp.com](https://harp-sample.herokuapp.com/) and its source at [github.com/zeke/harp-sample](https://github.com/zeke/harp-sample).
 
 ## Usage
 
-Check out the sample app at
-[github.com/zeke/harp-sample](https://github.com/zeke/harp-sample), or make your own from scratch:
-
-```
+```sh
 mkdir my-harp-app
 cd my-harp-app
 echo "hello world" > index.html
@@ -23,3 +24,7 @@ heroku config:set BUILDPACK_URL=https://github.com/zeke/harp-buildpack.git
 git push heroku master
 heroku open
 ```
+
+## License
+
+MIT

--- a/bin/detect
+++ b/bin/detect
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-if [ -f $1/index.jade ] || [ -f $1/index.html ]; then
+if [ -f $1/harp.json ] || [ -f $1/index.ejs ] || [ -f $1/index.html ] || [ -f $1/index.jade ] || [ -f $1/index.md ]; then
   echo "Harp.js static" && exit 0
 else
   echo "no" && exit 1


### PR DESCRIPTION
Currently the buildpack doesn't work if you have a harp.json file or just an `erb|md` `index` file. This fixes it.
